### PR TITLE
Fix typo on sign in link

### DIFF
--- a/src/main/resources/templates/registration.html
+++ b/src/main/resources/templates/registration.html
@@ -28,7 +28,7 @@
     <div th:if="${errorMessage}" style="color: red;">
         <h6 th:text="${errorMessage}"></h6>
     </div>
-    <a href="/login" class="btn btn-link">sing in</a>
+    <a href="/login" class="btn btn-link">sign in</a>
     <a href="/" class="btn btn-link">home</a>
 </div>
 </body>


### PR DESCRIPTION
## Summary
- correct typo on sign in link of registration page

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683fc5717414832fbcd54e6c2f3f5996